### PR TITLE
Merge/rating screen

### DIFF
--- a/app/src/main/java/com/gn41/appandroidkotlin/data/local/SessionManager.kt
+++ b/app/src/main/java/com/gn41/appandroidkotlin/data/local/SessionManager.kt
@@ -125,4 +125,54 @@ class SessionManager(context: Context) {
         current.add(rideId.toString())
         sharedPreferences.edit().putStringSet(key, current).apply()
     }
+
+    fun getPendingDriverRatingRideIds(authId: String): Set<Int> {
+        if (authId.isBlank()) return emptySet()
+        return sharedPreferences
+            .getStringSet("pending_driver_rating_$authId", emptySet())
+            ?.mapNotNull { it.toIntOrNull() }
+            ?.toSet()
+            ?: emptySet()
+    }
+
+    fun getPendingRiderRatingRideIds(authId: String): Set<Int> {
+        if (authId.isBlank()) return emptySet()
+        return sharedPreferences
+            .getStringSet("pending_rider_rating_$authId", emptySet())
+            ?.mapNotNull { it.toIntOrNull() }
+            ?.toSet()
+            ?: emptySet()
+    }
+
+    fun addPendingDriverRatingRideId(authId: String, rideId: Int) {
+        if (authId.isBlank()) return
+        val key = "pending_driver_rating_$authId"
+        val current = sharedPreferences.getStringSet(key, emptySet()).orEmpty().toMutableSet()
+        current.add(rideId.toString())
+        sharedPreferences.edit().putStringSet(key, current).apply()
+    }
+
+    fun addPendingRiderRatingRideId(authId: String, rideId: Int) {
+        if (authId.isBlank()) return
+        val key = "pending_rider_rating_$authId"
+        val current = sharedPreferences.getStringSet(key, emptySet()).orEmpty().toMutableSet()
+        current.add(rideId.toString())
+        sharedPreferences.edit().putStringSet(key, current).apply()
+    }
+
+    fun removePendingDriverRatingRideId(authId: String, rideId: Int) {
+        if (authId.isBlank()) return
+        val key = "pending_driver_rating_$authId"
+        val current = sharedPreferences.getStringSet(key, emptySet()).orEmpty().toMutableSet()
+        current.remove(rideId.toString())
+        sharedPreferences.edit().putStringSet(key, current).apply()
+    }
+
+    fun removePendingRiderRatingRideId(authId: String, rideId: Int) {
+        if (authId.isBlank()) return
+        val key = "pending_rider_rating_$authId"
+        val current = sharedPreferences.getStringSet(key, emptySet()).orEmpty().toMutableSet()
+        current.remove(rideId.toString())
+        sharedPreferences.edit().putStringSet(key, current).apply()
+    }
 }

--- a/app/src/main/java/com/gn41/appandroidkotlin/presentation/viewmodels/TripViewModel.kt
+++ b/app/src/main/java/com/gn41/appandroidkotlin/presentation/viewmodels/TripViewModel.kt
@@ -256,9 +256,22 @@ class TripViewModel(
         val persistedSkippedRiderIds = sessionManager.getSkippedRiderRatingRideIds(authId)
         skippedDriverIds.addAll(persistedSkippedDriverIds)
         skippedRiderIds.addAll(persistedSkippedRiderIds)
+
+        val persistedPendingDriverIds = sessionManager.getPendingDriverRatingRideIds(authId)
+        val persistedPendingRiderIds = sessionManager.getPendingRiderRatingRideIds(authId)
+        // Only add pending if not skipped (resolve inconsistencies)
+        val validPendingDriverIds = persistedPendingDriverIds.filter { it !in skippedDriverIds }
+        val validPendingRiderIds = persistedPendingRiderIds.filter { it !in skippedRiderIds }
+        pendingDriverIds.addAll(validPendingDriverIds)
+        pendingRiderIds.addAll(validPendingRiderIds)
+
         Log.d(
             "TripRating",
             "loaded persisted skipped authIdPresent=${authId.isNotBlank()} driver=${persistedSkippedDriverIds.size} rider=${persistedSkippedRiderIds.size}"
+        )
+        Log.d(
+            "TripRating",
+            "loaded pending authIdPresent=${authId.isNotBlank()} driver=${validPendingDriverIds.size} rider=${validPendingRiderIds.size}"
         )
 
         viewModelScope.launch {
@@ -422,8 +435,16 @@ class TripViewModel(
                         "driver reservations=${reservationsForFinishedRide.size} eligible=${eligibleReservations.size} rated=${ratedRiderIds.size}"
                     )
 
+                    // Check if all eligible riders are already rated
                     val hasPendingRidersToRate = candidateRiderIds.any { riderId -> riderId !in ratedRiderIds }
-                    if (hasPendingRidersToRate) finishedDriverRideForRating.id else null
+                    if (!hasPendingRidersToRate) {
+                        Log.d("TripRating", "remove driver pending because all riders already rated rideId=${finishedDriverRideForRating.id}")
+                        pendingDriverIds.remove(finishedDriverRideForRating.id)
+                        sessionManager.removePendingDriverRatingRideId(authId, finishedDriverRideForRating.id)
+                        null
+                    } else {
+                        if (hasPendingRidersToRate) finishedDriverRideForRating.id else null
+                    }
                 } else {
                     null
                 }
@@ -433,6 +454,7 @@ class TripViewModel(
                     detectedDriverPendingRideId !in skippedDriverIds
                 ) {
                     pendingDriverIds.add(detectedDriverPendingRideId)
+                    sessionManager.addPendingDriverRatingRideId(authId, detectedDriverPendingRideId)
                 }
 
                 val memoryDriverPendingRideId = pendingDriverIds
@@ -482,11 +504,31 @@ class TripViewModel(
                     "rider states reservation=$riderReservationState ride=$riderRideState"
                 )
 
+                // Validate if rider already rated the driver for this ride
+                var validDetectedRiderPendingRideId: Int? = detectedRiderPendingRideId
+                if (validDetectedRiderPendingRideId != null && rider != null && finishedRiderReservationForRating != null) {
+                    val driverId = finishedRiderReservationForRating.rides?.drivers?.id
+                    if (driverId != null) {
+                        val ratedDriverIds = ratingRepository.getRatedDriversForRide(
+                            token = token,
+                            rideId = validDetectedRiderPendingRideId,
+                            riderId = rider.id
+                        )
+                        if (driverId in ratedDriverIds) {
+                            Log.d("TripRating", "remove rider pending because driver already rated rideId=$validDetectedRiderPendingRideId")
+                            pendingRiderIds.remove(validDetectedRiderPendingRideId)
+                            sessionManager.removePendingRiderRatingRideId(authId, validDetectedRiderPendingRideId)
+                            validDetectedRiderPendingRideId = null
+                        }
+                    }
+                }
+
                 if (
-                    detectedRiderPendingRideId != null &&
-                    detectedRiderPendingRideId !in skippedRiderIds
+                    validDetectedRiderPendingRideId != null &&
+                    validDetectedRiderPendingRideId !in skippedRiderIds
                 ) {
-                    pendingRiderIds.add(detectedRiderPendingRideId)
+                    pendingRiderIds.add(validDetectedRiderPendingRideId)
+                    sessionManager.addPendingRiderRatingRideId(authId, validDetectedRiderPendingRideId)
                 }
 
                 val memoryRiderPendingRideId = pendingRiderIds
@@ -498,8 +540,8 @@ class TripViewModel(
                     currentPendingRiderRating != null &&
                         currentPendingRiderRating !in skippedRiderIds -> currentPendingRiderRating
                     memoryRiderPendingRideId != null -> memoryRiderPendingRideId
-                    detectedRiderPendingRideId != null &&
-                        detectedRiderPendingRideId !in skippedRiderIds -> detectedRiderPendingRideId
+                    validDetectedRiderPendingRideId != null &&
+                        validDetectedRiderPendingRideId !in skippedRiderIds -> validDetectedRiderPendingRideId
                     else -> null
                 }
 
@@ -724,6 +766,7 @@ class TripViewModel(
             skippedDriverSet(authId).add(rideId)
             pendingDriverSet(authId).remove(rideId)
             sessionManager.addSkippedDriverRatingRideId(authId, rideId)
+            sessionManager.removePendingDriverRatingRideId(authId, rideId)
             Log.d("TripRating", "persist skip driver authIdPresent=true rideId=$rideId")
         } else if (rideId != null) {
             Log.d("TripRating", "skip driver not persisted authIdPresent=false rideId=$rideId")
@@ -738,6 +781,7 @@ class TripViewModel(
             skippedRiderSet(authId).add(rideId)
             pendingRiderSet(authId).remove(rideId)
             sessionManager.addSkippedRiderRatingRideId(authId, rideId)
+            sessionManager.removePendingRiderRatingRideId(authId, rideId)
             Log.d("TripRating", "persist skip rider authIdPresent=true rideId=$rideId")
         } else if (rideId != null) {
             Log.d("TripRating", "skip rider not persisted authIdPresent=false rideId=$rideId")
@@ -752,8 +796,11 @@ class TripViewModel(
         val authId = resolveCurrentAuthId()
         if (rideId != null && authId != null) {
             pendingDriverSet(authId).remove(rideId)
+            sessionManager.removePendingDriverRatingRideId(authId, rideId)
+            Log.d("TripRating", "complete driver rating rideId=$rideId")
+        } else if (rideId != null) {
+            Log.d("TripRating", "complete driver rating not persisted rideId=$rideId")
         }
-        Log.d("TripRating", "complete driver rating rideId=$rideId")
         uiState = uiState.copy(finishedRideIdForRating = null)
     }
 
@@ -764,8 +811,11 @@ class TripViewModel(
         val authId = resolveCurrentAuthId()
         if (rideId != null && authId != null) {
             pendingRiderSet(authId).remove(rideId)
+            sessionManager.removePendingRiderRatingRideId(authId, rideId)
+            Log.d("TripRating", "complete rider rating rideId=$rideId")
+        } else if (rideId != null) {
+            Log.d("TripRating", "complete rider rating not persisted rideId=$rideId")
         }
-        Log.d("TripRating", "complete rider rating rideId=$rideId")
         uiState = uiState.copy(finishedRiderRideIdForRating = null)
     }
 
@@ -965,6 +1015,8 @@ class TripViewModel(
                     val authId = extractAuthIdFromToken(token)
                     if (!authId.isNullOrBlank()) {
                         pendingDriverSet(authId).add(rideId)
+                        sessionManager.addPendingDriverRatingRideId(authId, rideId)
+                        Log.d("TripRating", "persist pending driver rideId=$rideId")
                     }
                     newUiState.copy(finishedRideIdForRating = rideId)
                 } else {


### PR DESCRIPTION
This pull request introduces persistent storage and management of pending driver and rider rating ride IDs in the app, ensuring that pending ratings are accurately tracked and synchronized across app restarts and user sessions. The changes add new methods to `SessionManager` for storing, retrieving, and removing pending rating IDs, and update `TripViewModel` to utilize these methods for consistent state handling. Additional logic is added to resolve inconsistencies and avoid duplicate or unnecessary pending ratings.

**Persistent pending rating management:**

* Added new methods to `SessionManager` (`addPendingDriverRatingRideId`, `addPendingRiderRatingRideId`, `removePendingDriverRatingRideId`, `removePendingRiderRatingRideId`, `getPendingDriverRatingRideIds`, `getPendingRiderRatingRideIds`) to persistently store and manage pending driver and rider rating ride IDs using `SharedPreferences`.

* Updated `TripViewModel` to load pending driver and rider rating IDs from persistent storage at initialization, ensuring that only rides not already skipped are added to the pending sets.

**Synchronization and consistency improvements:**

* Ensured that pending rating IDs are removed from persistent storage when a rating is completed, skipped, or determined to be unnecessary (e.g., when all eligible riders/drivers have already been rated), to prevent stale or duplicate pending entries. [[1]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR438-R447) [[2]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR769) [[3]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR784) [[4]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bL755-R803) [[5]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bL767-R818)

* Added logic to prevent adding a ride to pending ratings if it has already been skipped, and to resolve inconsistencies between skipped and pending sets when loading from storage. [[1]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR259-R275) [[2]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR457)

**Validation enhancements:**

* Implemented validation to ensure that a rider is not prompted to rate a driver if the driver has already been rated for that ride, removing such rides from pending both in memory and persistent storage. [[1]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR507-R531) [[2]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bL501-R544)

**Logging and debugging:**

* Added additional logging to track the loading, persisting, and removal of pending rating IDs for better traceability and debugging. [[1]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR259-R275) [[2]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR438-R447) [[3]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR769) [[4]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR784) [[5]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bL755-R803) [[6]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bL767-R818) [[7]](diffhunk://#diff-2f9212cae69f5f35e839e284441c0ff0cee7adeada0c9f5c3f3df1dafc9b265bR1018-R1019)